### PR TITLE
feat(shell-api): Update serverVersions tag for getShardedDataDistribution to 6.0.3 MONGOSH-1303

### DIFF
--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -429,7 +429,7 @@ export default class Shard extends ShellApiWithMongoClass {
 
   @returnsPromise
   @apiVersions([])
-  @serverVersions(['6.1.0', ServerVersions.latest])
+  @serverVersions(['6.0.3', ServerVersions.latest])
   @returnType('AggregationCursor')
   async getShardedDataDistribution(options = {}): Promise<AggregationCursor> {
     this._emitShardApiCall('getShardedDataDistribution', {});


### PR DESCRIPTION
Update `serverVersions` tag for `getShardedDataDistribution` to 6.0.3

Part of the project PM-3019 (Backport of PM-2934 to v6.0)

The feature `getShardedDataDistribution` has already been backported to v6.0.